### PR TITLE
Fix error when render multiple files

### DIFF
--- a/src/dateurls.plugin.coffee
+++ b/src/dateurls.plugin.coffee
@@ -52,4 +52,4 @@ module.exports = (BasePlugin) ->
           else
               document.setUrl(dateUrl)
 
-          return next()
+      return next()


### PR DESCRIPTION
When there was multiple files in posts directory error was thrown. The issue was bug where return next() was called from incorrect scope. Here is the error that was thrown.

```
error: Something went wrong with the action
error: An error occured:
Error: A task's completion callback has fired when the task was already in a completed state, this is unexpected
    at Task.completionCallback (D:\Projects\blog\DocPad\blog\node_modules\docpad\node_modules\taskgroup\out\lib\taskgroup.js:131:15)
    at D:\Projects\blog\DocPad\blog\node_modules\docpad-plugin-dateurls\out\dateurls.plugin.js:65:18
    at Array.forEach (native)
    at Function._.each._.forEach (D:\Projects\blog\DocPad\blog\node_modules\docpad\node_modules\backbone\node_modules\underscore\underscore.js:79:11)
    at FilesCollection.Collection.(anonymous function) [as forEach] (D:\Projects\blog\DocPad\blog\node_modules\docpad\node_modules\backbone\backbone.js:956:24)
    at DateUrls.renderBefore (D:\Projects\blog\DocPad\blog\node_modules\docpad-plugin-dateurls\out\dateurls.plugin.js:56:19)
    at ambi (D:\Projects\blog\DocPad\blog\node_modules\docpad\node_modules\ambi\out\lib\ambi.js:23:18)
    at Task.<anonymous> (D:\Projects\blog\DocPad\blog\node_modules\docpad\node_modules\event-emitter-grouped\out\lib\event-emitter-grouped.js:38:23)
    at ambi (D:\Projects\blog\DocPad\blog\node_modules\docpad\node_modules\ambi\out\lib\ambi.js:23:18)
    at fire (D:\Projects\blog\DocPad\blog\node_modules\docpad\node_modules\taskgroup\out\lib\taskgroup.js:159:23)
    at b (domain.js:183:18)
    at Domain.run (domain.js:123:23)
    at Task.fire (D:\Projects\blog\DocPad\blog\node_modules\docpad\node_modules\taskgroup\out\lib\taskgroup.js:166:25)
    at process._tickDomainCallback (node.js:459:13)
```
