### PR TITLE
Allow individual files to opt out or override URLs set by this plugin

### DIFF
--- a/src/dateurls.plugin.coffee
+++ b/src/dateurls.plugin.coffee
@@ -46,11 +46,11 @@ module.exports = (BasePlugin) ->
           getFilename = 'outFilename'
         documents = @docpad.getCollection(config.collectionName)
         documents.forEach (document) ->
-          filename = document.get(getFilename)
-          if document.getMeta('dateurls-exclude')
-            console.log('dateurls excluding', filename)
-          else
-            console.log('dateurls including', filename)
+          overrideUrl = document.getMeta('dateurls-override')
+          if overrideUrl && typeof overrideUrl is 'string'
+            document.setUrl(overrideUrl)
+          else if not document.getMeta('dateurls-exclude')
+            filename = document.get(getFilename)            
             dateUrl = moment.utc(document.getMeta('date')).format(config.dateFormat)+"/"+filename.replace(post_date_regex,'')
             if config.cleanurl
               document.setUrl(dateUrl + if trailingSlashes then '/' else '')


### PR DESCRIPTION
This patch would allow individual files to opt out from having their URLs set by this plugin, via a flag in file metadata, e.g.

```
----
dateurls-exclude: true
----
```

Alternatively, one may override the URLs manually, e.g.

```
----
dateurls-override: "/2018/07/08/this-post-appears-in-the-future"
----
```
